### PR TITLE
extension promise should be void

### DIFF
--- a/vscode-extension/src/main/ts/extension.ts
+++ b/vscode-extension/src/main/ts/extension.ts
@@ -94,7 +94,7 @@ function startLanguageServer() {
   vscode.window.withProgress(
     { location: vscode.ProgressLocation.Window },
     (progress) => {
-      return new Promise((resolve, reject) => {
+      return new Promise<void>((resolve, reject) => {
         if (!extensionContext) {
           //something very bad happened!
           resolve();


### PR DESCRIPTION
Hey team - the promise in startLanguageServer seems to need a void type in order to compile.