### PR TITLE
fix deadloop when visit ElvisOperatorExpression

### DIFF
--- a/src/main/java/net/prominic/groovyls/compiler/ast/ASTNodeVisitor.java
+++ b/src/main/java/net/prominic/groovyls/compiler/ast/ASTNodeVisitor.java
@@ -621,14 +621,14 @@ public class ASTNodeVisitor extends ClassCodeVisitorSupport {
 		}
 	}
 
-	public void visitShortTernaryExpression(ElvisOperatorExpression node) {
-		pushASTNode(node);
-		try {
-			super.visitShortTernaryExpression(node);
-		} finally {
-			popASTNode();
-		}
-	}
+	// public void visitShortTernaryExpression(ElvisOperatorExpression node) {
+	// 	pushASTNode(node);
+	// 	try {
+	// 		super.visitShortTernaryExpression(node);
+	// 	} finally {
+	// 		popASTNode();
+	// 	}
+	// }
 
 	public void visitPostfixExpression(PostfixExpression node) {
 		pushASTNode(node);


### PR DESCRIPTION
Before, the `visitShortTernaryExpression` method pushes the node to the stack, and the `visitShortTernaryExpression` method pushes the node to the stack again. Then the node's parent is the node itself. It causes deadloop in `getParent` method.