### PR TITLE
vscode-extension: Create and reuse one output channel instead of creating/deleting on language server restart

### DIFF
--- a/vscode-extension/src/main/ts/extension.ts
+++ b/vscode-extension/src/main/ts/extension.ts
@@ -39,6 +39,8 @@ let extensionContext: vscode.ExtensionContext | null = null;
 let languageClient: LanguageClient | null = null;
 let javaPath: string | null = null;
 
+const channel = vscode.window.createOutputChannel('Groovy');
+
 function onDidChangeConfiguration(event: vscode.ConfigurationChangeEvent) {
   if (event.affectsConfiguration("groovy.java.home")) {
     javaPath = findJava();
@@ -132,6 +134,7 @@ function startLanguageServer() {
             //this is just the default behavior, but we need to define both
             protocol2Code: (value) => vscode.Uri.parse(value),
           },
+          outputChannel: channel
         };
         let args = [
           "-jar",

--- a/vscode-extension/src/main/ts/extension.ts
+++ b/vscode-extension/src/main/ts/extension.ts
@@ -38,8 +38,7 @@ const LABEL_RELOAD_WINDOW = "Reload Window";
 let extensionContext: vscode.ExtensionContext | null = null;
 let languageClient: LanguageClient | null = null;
 let javaPath: string | null = null;
-
-const channel = vscode.window.createOutputChannel('Groovy');
+let groovyOutputChannel: vscode.OutputChannel | undefined;
 
 function onDidChangeConfiguration(event: vscode.ConfigurationChangeEvent) {
   if (event.affectsConfiguration("groovy.java.home")) {
@@ -77,6 +76,7 @@ function restartLanguageServer() {
 
 export function activate(context: vscode.ExtensionContext) {
   extensionContext = context;
+  groovyOutputChannel = vscode.window.createOutputChannel("Groovy");
   javaPath = findJava();
   vscode.workspace.onDidChangeConfiguration(onDidChangeConfiguration);
 
@@ -134,7 +134,7 @@ function startLanguageServer() {
             //this is just the default behavior, but we need to define both
             protocol2Code: (value) => vscode.Uri.parse(value),
           },
-          outputChannel: channel
+          outputChannel: groovyOutputChannel
         };
         let args = [
           "-jar",


### PR DESCRIPTION
Before this change, every time you run the "Groovy: Restart Groovy language server" task, a new "Groovy Language Server" output channel is created, and the old one is not removed:
<img width="310" height="323" alt="image-ezgif com-crop" src="https://github.com/user-attachments/assets/74399d76-49f9-4a9a-a50e-902cffb3472f" />

After this change, all language servers will reuse a single "Groovy" output channel, so that when debugging the language server in VS Code and a restart is required, you don't have to reselect the latest output channel in the dropdown menu.