### PR TITLE
Use `CompletionItemLabelDetails` from LSP4J 0.20.0 for detailed completion list

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,7 @@ repositories  {
 }
 
 dependencies {
-  implementation "org.eclipse.lsp4j:org.eclipse.lsp4j:0.12.0"
-  implementation "org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.12.0"
+  implementation "org.eclipse.lsp4j:org.eclipse.lsp4j:0.20.0"
   implementation "org.apache.groovy:groovy:4.0.26"
   implementation "com.google.code.gson:gson:2.13.1"
   implementation "io.github.classgraph:classgraph:4.8.179"

--- a/src/main/java/net/prominic/groovyls/GroovyServices.java
+++ b/src/main/java/net/prominic/groovyls/GroovyServices.java
@@ -79,6 +79,7 @@ import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TypeDefinitionParams;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.WorkspaceSymbol;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.LanguageClient;
@@ -359,7 +360,7 @@ public class GroovyServices implements TextDocumentService, WorkspaceService, La
 	}
 
 	@Override
-	public CompletableFuture<List<? extends SymbolInformation>> symbol(WorkspaceSymbolParams params) {
+	public CompletableFuture<Either<List<? extends SymbolInformation>, List<? extends WorkspaceSymbol>>> symbol(WorkspaceSymbolParams params) {
 		WorkspaceSymbolProvider provider = new WorkspaceSymbolProvider(astVisitor);
 		return provider.provideWorkspaceSymbols(params.getQuery());
 	}

--- a/src/main/java/net/prominic/groovyls/providers/CompletionProvider.java
+++ b/src/main/java/net/prominic/groovyls/providers/CompletionProvider.java
@@ -385,6 +385,9 @@ public class CompletionProvider {
 			CompletionItem item = new CompletionItem();
 			item.setLabel(variable.getName());
 			item.setKind(GroovyLanguageServerUtils.astNodeToCompletionItemKind((ASTNode) variable));
+			CompletionItemLabelDetails labelDetails = new CompletionItemLabelDetails();
+			labelDetails.setDescription(variable.getType().getNameWithoutPackage());
+			item.setLabelDetails(labelDetails);
 			if (variable instanceof AnnotatedNode) {
 				AnnotatedNode annotatedVar = (AnnotatedNode) variable;
 				String markdownDocs = GroovydocUtils.groovydocToMarkdownDescription(annotatedVar.getGroovydoc());
@@ -456,7 +459,9 @@ public class CompletionProvider {
 			CompletionItem item = new CompletionItem();
 			item.setLabel(classNode.getNameWithoutPackage());
 			item.setKind(GroovyLanguageServerUtils.astNodeToCompletionItemKind(classNode));
-			item.setDetail(packageName);
+			CompletionItemLabelDetails labelDetails = new CompletionItemLabelDetails();
+			labelDetails.setDescription(packageName);
+			item.setLabelDetails(labelDetails);
 			String markdownDocs = GroovydocUtils.groovydocToMarkdownDescription(classNode.getGroovydoc());
 			if (markdownDocs != null) {
 				item.setDocumentation(new MarkupContent(MarkupKind.MARKDOWN, markdownDocs));
@@ -496,8 +501,10 @@ public class CompletionProvider {
 			String packageName = classInfo.getPackageName();
 			CompletionItem item = new CompletionItem();
 			item.setLabel(classInfo.getSimpleName());
-			item.setDetail(packageName);
 			item.setKind(classInfoToCompletionItemKind(classInfo));
+			CompletionItemLabelDetails labelDetails = new CompletionItemLabelDetails();
+			labelDetails.setDescription(packageName);
+			item.setLabelDetails(labelDetails);
 			if (packageName != null && !packageName.equals(enclosingPackageName) && !importNames.contains(className)) {
 				List<TextEdit> additionalTextEdits = new ArrayList<>();
 				TextEdit addImportEdit = createAddImportTextEdit(className, addImportRange);

--- a/src/main/java/net/prominic/groovyls/providers/CompletionProvider.java
+++ b/src/main/java/net/prominic/groovyls/providers/CompletionProvider.java
@@ -36,6 +36,7 @@ import org.codehaus.groovy.ast.FieldNode;
 import org.codehaus.groovy.ast.ImportNode;
 import org.codehaus.groovy.ast.MethodNode;
 import org.codehaus.groovy.ast.ModuleNode;
+import org.codehaus.groovy.ast.Parameter;
 import org.codehaus.groovy.ast.PropertyNode;
 import org.codehaus.groovy.ast.VariableScope;
 import org.codehaus.groovy.ast.expr.ConstructorCallExpression;
@@ -48,6 +49,7 @@ import org.codehaus.groovy.ast.stmt.Statement;
 import org.eclipse.lsp4j.CompletionContext;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionItemKind;
+import org.eclipse.lsp4j.CompletionItemLabelDetails;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.MarkupKind;
@@ -293,6 +295,9 @@ public class CompletionProvider {
 			if (markdownDocs != null) {
 				item.setDocumentation(new MarkupContent(MarkupKind.MARKDOWN, markdownDocs));
 			}
+			CompletionItemLabelDetails labelDetails = new CompletionItemLabelDetails();
+			labelDetails.setDescription(property.getType().getNameWithoutPackage());
+			item.setLabelDetails(labelDetails);
 			return item;
 		}).collect(Collectors.toList());
 		items.addAll(propItems);
@@ -312,6 +317,9 @@ public class CompletionProvider {
 			if (markdownDocs != null) {
 				item.setDocumentation(new MarkupContent(MarkupKind.MARKDOWN, markdownDocs));
 			}
+			CompletionItemLabelDetails labelDetails = new CompletionItemLabelDetails();
+			labelDetails.setDescription(field.getType().getNameWithoutPackage());
+			item.setLabelDetails(labelDetails);
 			return item;
 		}).collect(Collectors.toList());
 		items.addAll(fieldItems);
@@ -330,6 +338,17 @@ public class CompletionProvider {
 		}).map(method -> {
 			CompletionItem item = new CompletionItem();
 			item.setLabel(method.getName());
+			String methodParams = "(";
+			for (Parameter p : method.getParameters()) {
+				methodParams += p.getType().getNameWithoutPackage() + ' ' + p.getName() + ", ";
+			}
+			if (!methodParams.equals("("))
+				methodParams = methodParams.substring(0, methodParams.length() - 2);
+			methodParams += ')';
+			CompletionItemLabelDetails labelDetails = new CompletionItemLabelDetails();
+			labelDetails.setDetail(methodParams);
+			labelDetails.setDescription(method.getReturnType().getNameWithoutPackage());
+			item.setLabelDetails(labelDetails);
 			item.setKind(GroovyLanguageServerUtils.astNodeToCompletionItemKind(method));
 			String markdownDocs = GroovydocUtils.groovydocToMarkdownDescription(method.getGroovydoc());
 			if (markdownDocs != null) {

--- a/src/main/java/net/prominic/groovyls/providers/WorkspaceSymbolProvider.java
+++ b/src/main/java/net/prominic/groovyls/providers/WorkspaceSymbolProvider.java
@@ -31,6 +31,8 @@ import org.codehaus.groovy.ast.FieldNode;
 import org.codehaus.groovy.ast.MethodNode;
 import org.codehaus.groovy.ast.PropertyNode;
 import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.WorkspaceSymbol;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 import net.prominic.groovyls.compiler.ast.ASTNodeVisitor;
 import net.prominic.groovyls.compiler.util.GroovyASTUtils;
@@ -43,11 +45,11 @@ public class WorkspaceSymbolProvider {
 		this.ast = ast;
 	}
 
-	public CompletableFuture<List<? extends SymbolInformation>> provideWorkspaceSymbols(String query) {
+	public CompletableFuture<Either<List<? extends SymbolInformation>, List<? extends WorkspaceSymbol>>> provideWorkspaceSymbols(String query) {
 		if (ast == null) {
 			// this shouldn't happen, but let's avoid an exception if something
 			// goes terribly wrong.
-			return CompletableFuture.completedFuture(Collections.emptyList());
+			return CompletableFuture.completedFuture(Either.forLeft(Collections.emptyList()));
 		}
 		String lowerCaseQuery = query.toLowerCase();
 		List<ASTNode> nodes = ast.getNodes();
@@ -92,6 +94,6 @@ public class WorkspaceSymbolProvider {
 			// this should never happen
 			return null;
 		}).filter(symbolInformation -> symbolInformation != null).collect(Collectors.toList());
-		return CompletableFuture.completedFuture(symbols);
+		return CompletableFuture.completedFuture(Either.forLeft(symbols));
 	}
 }

--- a/src/test/java/net/prominic/groovyls/GroovyServicesCompletionTests.java
+++ b/src/test/java/net/prominic/groovyls/GroovyServicesCompletionTests.java
@@ -123,7 +123,9 @@ class GroovyServicesCompletionTests {
 		List<CompletionItem> items = result.getLeft();
 		Assertions.assertTrue(items.size() > 0);
 		List<CompletionItem> filteredItems = items.stream().filter(item -> {
-			return item.getLabel().equals("charAt") && item.getKind().equals(CompletionItemKind.Method);
+			return item.getLabel().equals("charAt") && item.getKind().equals(CompletionItemKind.Method) &&
+					item.getLabelDetails().getDetail().equals("(int arg0)") &&
+					item.getLabelDetails().getDescription().equals("char");
 		}).collect(Collectors.toList());
 		Assertions.assertEquals(1, filteredItems.size());
 	}
@@ -149,7 +151,9 @@ class GroovyServicesCompletionTests {
 		List<CompletionItem> items = result.getLeft();
 		Assertions.assertTrue(items.size() > 0);
 		List<CompletionItem> filteredItems = items.stream().filter(item -> {
-			return item.getLabel().equals("charAt") && item.getKind().equals(CompletionItemKind.Method);
+			return item.getLabel().equals("charAt") && item.getKind().equals(CompletionItemKind.Method) &&
+					item.getLabelDetails().getDetail().equals("(int arg0)") &&
+					item.getLabelDetails().getDescription().equals("char");
 		}).collect(Collectors.toList());
 		Assertions.assertEquals(1, filteredItems.size());
 	}
@@ -175,7 +179,8 @@ class GroovyServicesCompletionTests {
 		List<CompletionItem> items = result.getLeft();
 		Assertions.assertTrue(items.size() > 0);
 		List<CompletionItem> filteredItems = items.stream().filter(item -> {
-			return item.getLabel().equals("memberVar") && item.getKind().equals(CompletionItemKind.Field);
+			return item.getLabel().equals("memberVar") && item.getKind().equals(CompletionItemKind.Field) &&
+					item.getLabelDetails().getDescription().equals("String");
 		}).collect(Collectors.toList());
 		Assertions.assertEquals(1, filteredItems.size());
 	}
@@ -201,7 +206,8 @@ class GroovyServicesCompletionTests {
 		List<CompletionItem> items = result.getLeft();
 		Assertions.assertTrue(items.size() > 0);
 		List<CompletionItem> filteredItems = items.stream().filter(item -> {
-			return item.getLabel().equals("staticMethod") && item.getKind().equals(CompletionItemKind.Method);
+			return item.getLabel().equals("staticMethod") && item.getKind().equals(CompletionItemKind.Method) &&
+					item.getLabelDetails().getDescription().equals("void");
 		}).collect(Collectors.toList());
 		Assertions.assertEquals(1, filteredItems.size());
 	}
@@ -227,7 +233,9 @@ class GroovyServicesCompletionTests {
 		List<CompletionItem> items = result.getLeft();
 		Assertions.assertTrue(items.size() > 0);
 		List<CompletionItem> filteredItems = items.stream().filter(item -> {
-			return item.getLabel().equals("charAt") && item.getKind().equals(CompletionItemKind.Method);
+			return item.getLabel().equals("charAt") && item.getKind().equals(CompletionItemKind.Method) &&
+					item.getLabelDetails().getDetail().equals("(int arg0)") &&
+					item.getLabelDetails().getDescription().equals("char");
 		}).collect(Collectors.toList());
 		Assertions.assertEquals(1, filteredItems.size());
 	}
@@ -252,7 +260,9 @@ class GroovyServicesCompletionTests {
 		Assertions.assertTrue(result.isLeft());
 		List<CompletionItem> items = result.getLeft();
 		List<CompletionItem> filteredItems = items.stream().filter(item -> {
-			return item.getLabel().equals("charAt") && item.getKind().equals(CompletionItemKind.Method);
+			return item.getLabel().equals("charAt") && item.getKind().equals(CompletionItemKind.Method) &&
+					item.getLabelDetails().getDetail().equals("(int arg0)") &&
+					item.getLabelDetails().getDescription().equals("char");
 		}).collect(Collectors.toList());
 		Assertions.assertEquals(1, filteredItems.size());
 	}
@@ -282,8 +292,12 @@ class GroovyServicesCompletionTests {
 		List<CompletionItem> items = result.getLeft();
 		Assertions.assertEquals(2, items.size());
 		List<CompletionItem> filteredItems = items.stream().filter(item -> {
-			return (item.getLabel().equals("abc") && item.getKind().equals(CompletionItemKind.Method))
-					|| (item.getLabel().equals("abcdef") && item.getKind().equals(CompletionItemKind.Method));
+			return (item.getLabel().equals("abc") && item.getKind().equals(CompletionItemKind.Method) &&
+					item.getLabelDetails().getDetail().equals("()") &&
+					item.getLabelDetails().getDescription().equals("Object"))
+					|| (item.getLabel().equals("abcdef") && item.getKind().equals(CompletionItemKind.Method)
+							&& item.getLabelDetails().getDetail().equals("()") &&
+							item.getLabelDetails().getDescription().equals("Object"));
 		}).collect(Collectors.toList());
 		Assertions.assertEquals(2, filteredItems.size());
 
@@ -296,6 +310,8 @@ class GroovyServicesCompletionTests {
 		CompletionItem item = items.get(0);
 		Assertions.assertEquals("abcdef", item.getLabel());
 		Assertions.assertEquals(CompletionItemKind.Method, item.getKind());
+		Assertions.assertEquals("()", item.getLabelDetails().getDetail());
+		Assertions.assertEquals("Object", item.getLabelDetails().getDescription());
 	}
 
 	@Test
@@ -320,7 +336,9 @@ class GroovyServicesCompletionTests {
 		List<CompletionItem> items = result.getLeft();
 		Assertions.assertTrue(items.size() > 0);
 		List<CompletionItem> filteredItems = items.stream().filter(item -> {
-			return item.getLabel().equals("charAt") && item.getKind().equals(CompletionItemKind.Method);
+			return item.getLabel().equals("charAt") && item.getKind().equals(CompletionItemKind.Method) &&
+					item.getLabelDetails().getDetail().equals("(int arg0)") &&
+					item.getLabelDetails().getDescription().equals("char");
 		}).collect(Collectors.toList());
 		Assertions.assertEquals(1, filteredItems.size());
 	}
@@ -347,7 +365,9 @@ class GroovyServicesCompletionTests {
 		List<CompletionItem> items = result.getLeft();
 		Assertions.assertTrue(items.size() > 0);
 		List<CompletionItem> filteredItems = items.stream().filter(item -> {
-			return item.getLabel().equals("charAt") && item.getKind().equals(CompletionItemKind.Method);
+			return item.getLabel().equals("charAt") && item.getKind().equals(CompletionItemKind.Method) &&
+					item.getLabelDetails().getDetail().equals("(int arg0)") &&
+					item.getLabelDetails().getDescription().equals("char");
 		}).collect(Collectors.toList());
 		Assertions.assertEquals(1, filteredItems.size());
 	}
@@ -372,7 +392,8 @@ class GroovyServicesCompletionTests {
 		Assertions.assertTrue(result.isLeft());
 		List<CompletionItem> items = result.getLeft();
 		List<CompletionItem> filteredItems = items.stream().filter(item -> {
-			return item.getLabel().equals("memberVar") && item.getKind().equals(CompletionItemKind.Field);
+			return item.getLabel().equals("memberVar") && item.getKind().equals(CompletionItemKind.Field) &&
+					item.getLabelDetails().getDescription().equals("String");
 		}).collect(Collectors.toList());
 		Assertions.assertEquals(1, filteredItems.size());
 	}
@@ -397,7 +418,8 @@ class GroovyServicesCompletionTests {
 		Assertions.assertTrue(result.isLeft());
 		List<CompletionItem> items = result.getLeft();
 		List<CompletionItem> filteredItems = items.stream().filter(item -> {
-			return item.getLabel().equals("memberVar") && item.getKind().equals(CompletionItemKind.Field);
+			return item.getLabel().equals("memberVar") && item.getKind().equals(CompletionItemKind.Field) &&
+					item.getLabelDetails().getDescription().equals("String");
 		}).collect(Collectors.toList());
 		Assertions.assertEquals(1, filteredItems.size());
 	}
@@ -422,7 +444,9 @@ class GroovyServicesCompletionTests {
 		Assertions.assertTrue(result.isLeft());
 		List<CompletionItem> items = result.getLeft();
 		List<CompletionItem> filteredItems = items.stream().filter(item -> {
-			return item.getLabel().equals("memberMethod") && item.getKind().equals(CompletionItemKind.Method);
+			return item.getLabel().equals("memberMethod") && item.getKind().equals(CompletionItemKind.Method) &&
+					item.getLabelDetails().getDetail().equals("()") &&
+					item.getLabelDetails().getDescription().equals("String");
 		}).collect(Collectors.toList());
 		Assertions.assertEquals(1, filteredItems.size());
 	}
@@ -447,7 +471,9 @@ class GroovyServicesCompletionTests {
 		Assertions.assertTrue(result.isLeft());
 		List<CompletionItem> items = result.getLeft();
 		List<CompletionItem> filteredItems = items.stream().filter(item -> {
-			return item.getLabel().equals("memberMethod") && item.getKind().equals(CompletionItemKind.Method);
+			return item.getLabel().equals("memberMethod") && item.getKind().equals(CompletionItemKind.Method) &&
+					item.getLabelDetails().getDetail().equals("()") &&
+					item.getLabelDetails().getDescription().equals("String");
 		}).collect(Collectors.toList());
 		Assertions.assertEquals(1, filteredItems.size());
 	}
@@ -471,7 +497,8 @@ class GroovyServicesCompletionTests {
 		Assertions.assertTrue(result.isLeft());
 		List<CompletionItem> items = result.getLeft();
 		List<CompletionItem> filteredItems = items.stream().filter(item -> {
-			return item.getLabel().equals("paramName") && item.getKind().equals(CompletionItemKind.Variable);
+			return item.getLabel().equals("paramName") && item.getKind().equals(CompletionItemKind.Variable) &&
+					item.getLabelDetails().getDescription().equals("String");
 		}).collect(Collectors.toList());
 		Assertions.assertEquals(1, filteredItems.size());
 	}
@@ -495,7 +522,8 @@ class GroovyServicesCompletionTests {
 		Assertions.assertTrue(result.isLeft());
 		List<CompletionItem> items = result.getLeft();
 		List<CompletionItem> filteredItems = items.stream().filter(item -> {
-			return item.getLabel().equals("paramName") && item.getKind().equals(CompletionItemKind.Variable);
+			return item.getLabel().equals("paramName") && item.getKind().equals(CompletionItemKind.Variable) &&
+					item.getLabelDetails().getDescription().equals("String");
 		}).collect(Collectors.toList());
 		Assertions.assertEquals(1, filteredItems.size());
 	}
@@ -520,7 +548,8 @@ class GroovyServicesCompletionTests {
 		Assertions.assertTrue(result.isLeft());
 		List<CompletionItem> items = result.getLeft();
 		List<CompletionItem> filteredItems = items.stream().filter(item -> {
-			return item.getLabel().equals("localVar") && item.getKind().equals(CompletionItemKind.Variable);
+			return item.getLabel().equals("localVar") && item.getKind().equals(CompletionItemKind.Variable) &&
+					item.getLabelDetails().getDescription().equals("String");
 		}).collect(Collectors.toList());
 		Assertions.assertEquals(1, filteredItems.size());
 	}
@@ -545,7 +574,8 @@ class GroovyServicesCompletionTests {
 		Assertions.assertTrue(result.isLeft());
 		List<CompletionItem> items = result.getLeft();
 		List<CompletionItem> filteredItems = items.stream().filter(item -> {
-			return item.getLabel().equals("localVar") && item.getKind().equals(CompletionItemKind.Variable);
+			return item.getLabel().equals("localVar") && item.getKind().equals(CompletionItemKind.Variable) &&
+					item.getLabelDetails().getDescription().equals("String");
 		}).collect(Collectors.toList());
 		Assertions.assertEquals(1, filteredItems.size());
 	}
@@ -572,7 +602,8 @@ class GroovyServicesCompletionTests {
 		Assertions.assertTrue(result.isLeft());
 		List<CompletionItem> items = result.getLeft();
 		List<CompletionItem> filteredItems = items.stream().filter(item -> {
-			return item.getLabel().equals("localVar") && item.getKind().equals(CompletionItemKind.Variable);
+			return item.getLabel().equals("localVar") && item.getKind().equals(CompletionItemKind.Variable) &&
+					item.getLabelDetails().getDescription().equals("String");
 		}).collect(Collectors.toList());
 		Assertions.assertEquals(1, filteredItems.size());
 	}
@@ -598,8 +629,9 @@ class GroovyServicesCompletionTests {
 		List<CompletionItem> items = result.getLeft();
 		Assertions.assertTrue(items.size() > 0);
 		List<CompletionItem> filteredItems = items.stream().filter(item -> {
-			return item.getLabel().equals("Completion") && item.getDetail().equals("com.example")
-					&& item.getKind().equals(CompletionItemKind.Class);
+			return item.getLabel().equals("Completion") &&
+					item.getLabelDetails().getDescription().equals("com.example") &&
+					item.getKind().equals(CompletionItemKind.Class);
 		}).collect(Collectors.toList());
 		Assertions.assertEquals(1, filteredItems.size());
 	}
@@ -624,8 +656,9 @@ class GroovyServicesCompletionTests {
 		List<CompletionItem> items = result.getLeft();
 		Assertions.assertTrue(items.size() > 0);
 		List<CompletionItem> filteredItems = items.stream().filter(item -> {
-			return item.getLabel().equals("ArrayList") && item.getDetail().equals("java.util")
-					&& item.getKind().equals(CompletionItemKind.Class);
+			return item.getLabel().equals("ArrayList") &&
+					item.getLabelDetails().getDescription().equals("java.util") &&
+					item.getKind().equals(CompletionItemKind.Class);
 		}).collect(Collectors.toList());
 		Assertions.assertEquals(1, filteredItems.size());
 	}


### PR DESCRIPTION
- Bump LSP4J to 0.20.0
- Remove `org.eclipse.lsp4j.jsonrpc` as an explicit dependency as to let `org.eclipse.lsp4j` itself require the version of `org.eclipse.lsp4j.jsonrpc` it needs
- Use `CompletionItemLabelDetails` object to set `detail` to the argument list of methods and `description` to the return type of methods and the types of properties/fields. This allows for a nicer looking completion menu showing much more information about methods/properties/fields at a glance in VS Code. (This also brings the completion menu to parity with [Eclipse JDT LS](https://github.com/eclipse-jdtls/eclipse.jdt.ls).)
- Modify test cases to check `CompletionItemLabelDetails` objects
- Use `CompletionItemLabelDetails` for class/type completions to show the package of each class as the `description` field. The package name shows up in the same place that method/field/variable types do.

## Visual demonstration
With the following class available in scope, below are screenshots of the completion menu after typing `new TestClass().`:
```groovy
class TestClass {
    int aInt = 3
    byte aByte = 4
    String aString = "hello"
    abstract def aMethod()
    abstract float anotherMethod(short a, double b)
    abstract List aThirdMethod(x)
}
```

### Before
<img width="524" height="305" alt="image" src="https://github.com/user-attachments/assets/888c67aa-dc23-4f17-99fe-c1604e631f0d" />

### After
<img width="524" height="311" alt="image" src="https://github.com/user-attachments/assets/a97e29db-6620-4faa-919b-384c6b22213a" />

