### PR TITLE
Provide definitions for implicitly-defined script classes

### DIFF
--- a/src/main/java/net/prominic/groovyls/providers/DefinitionProvider.java
+++ b/src/main/java/net/prominic/groovyls/providers/DefinitionProvider.java
@@ -25,9 +25,12 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.ConstructorNode;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
@@ -56,7 +59,7 @@ public class DefinitionProvider {
 		}
 
 		ASTNode definitionNode = GroovyASTUtils.getDefinition(offsetNode, true, ast);
-		if (definitionNode == null || definitionNode.getLineNumber() == -1 || definitionNode.getColumnNumber() == -1) {
+		if (definitionNode == null) {
 			return CompletableFuture.completedFuture(Either.forLeft(Collections.emptyList()));
 		}
 
@@ -67,6 +70,15 @@ public class DefinitionProvider {
 
 		Location location = GroovyLanguageServerUtils.astNodeToLocation(definitionNode, definitionURI);
 		if (location == null) {
+			if (definitionNode instanceof ConstructorNode) {
+				// This will "fall-through" to the if-block below!
+				definitionNode = ((ConstructorNode) definitionNode).getDeclaringClass();
+				definitionURI = ast.getURI(definitionNode);
+			}
+			if (definitionNode instanceof ClassNode) {
+				location = new Location(definitionURI.toString(), new Range(new Position(), new Position(1, 1)));
+				return CompletableFuture.completedFuture(Either.forLeft(Collections.singletonList(location)));
+			}
 			return CompletableFuture.completedFuture(Either.forLeft(Collections.emptyList()));
 		}
 

--- a/src/main/java/net/prominic/groovyls/providers/ReferenceProvider.java
+++ b/src/main/java/net/prominic/groovyls/providers/ReferenceProvider.java
@@ -57,6 +57,8 @@ public class ReferenceProvider {
 		List<ASTNode> references = GroovyASTUtils.getReferences(offsetNode, ast);
 		List<Location> locations = references.stream().map(node -> {
 			URI uri = ast.getURI(node);
+			if (uri == null)
+				return null;
 			return GroovyLanguageServerUtils.astNodeToLocation(node, uri);
 		}).filter(location -> location != null).collect(Collectors.toList());
 

--- a/src/test/java/net/prominic/groovyls/GroovyServicesDefinitionTests.java
+++ b/src/test/java/net/prominic/groovyls/GroovyServicesDefinitionTests.java
@@ -438,6 +438,50 @@ class GroovyServicesDefinitionTests {
 		Assertions.assertEquals(1, location.getRange().getEnd().getCharacter());
 	}
 
+	@Test
+	void testImplicitClassDefinitionFromConstructorCall() throws Exception {
+		Path filePath = srcRoot.resolve("Definitions.groovy");
+		String uri = filePath.toUri().toString();
+		TextDocumentItem textDocumentItem = new TextDocumentItem(uri, LANGUAGE_GROOVY, 1, "new Definitions()");
+		services.didOpen(new DidOpenTextDocumentParams(textDocumentItem));
+		TextDocumentIdentifier textDocument = new TextDocumentIdentifier(uri);
+		Position position = new Position(0, 10);
+		List<? extends Location> locations = services.definition(new DefinitionParams(textDocument, position)).get()
+				.getLeft();
+		Assertions.assertEquals(1, locations.size());
+		Location location = locations.get(0);
+		Assertions.assertEquals(uri, location.getUri());
+		Assertions.assertEquals(0, location.getRange().getStart().getLine());
+		Assertions.assertEquals(0, location.getRange().getStart().getCharacter());
+		Assertions.assertEquals(1, location.getRange().getEnd().getLine());
+		Assertions.assertEquals(1, location.getRange().getEnd().getCharacter());
+	}
+
+	@Test
+	void testImplicitClassDefinitionFromImport() throws Exception {
+		Path filePath = srcRoot.resolve("Definitions.groovy");
+		String uri = filePath.toUri().toString();
+		TextDocumentItem textDocumentItem = new TextDocumentItem(uri, LANGUAGE_GROOVY, 1, "");
+		services.didOpen(new DidOpenTextDocumentParams(textDocumentItem));
+
+		Path filePath2 = srcRoot.resolve("Definitions2.groovy");
+		String uri2 = filePath2.toUri().toString();
+		TextDocumentItem textDocumentItem2 = new TextDocumentItem(uri2, LANGUAGE_GROOVY, 1, "import Definitions");
+		services.didOpen(new DidOpenTextDocumentParams(textDocumentItem2));
+
+		TextDocumentIdentifier textDocument = new TextDocumentIdentifier(uri2);
+		Position position = new Position(0, 10);
+		List<? extends Location> locations = services.definition(new DefinitionParams(textDocument, position)).get()
+				.getLeft();
+		Assertions.assertEquals(1, locations.size());
+		Location location = locations.get(0);
+		Assertions.assertEquals(uri, location.getUri());
+		Assertions.assertEquals(0, location.getRange().getStart().getLine());
+		Assertions.assertEquals(0, location.getRange().getStart().getCharacter());
+		Assertions.assertEquals(1, location.getRange().getEnd().getLine());
+		Assertions.assertEquals(1, location.getRange().getEnd().getCharacter());
+	}
+
 	// --- parameters
 
 	@Test


### PR DESCRIPTION
### Changes
- Implement go-to-definition for `ClassExpression`s, `ConstructorCallExpression`s, and `ImportNode`s using implicit script classes, where otherwise scripts were required to return an expression (or have its last statement be an expression) and the definition pointed to that expression.
- ~~Fix `NullPointerException` when requesting references for a `ClassExpression` of an implicit script class within the same file. This was found when ctrl+clicking on the expression `moduleA` within the file `moduleA.groovy` while another file contained the statement `import moduleA`.~~ See #118
- Add test cases to `GroovyServicesDefinitionTests` for implicit script class definition requests

### Visual testing
Create the file `moduleA.groovy`. Do **not** define an *explicit script class* like `class moduleA {}`. Instead write a static and an instance method at the top-level of the script:
```groovy
static def staticFunc() {}
def instanceFunc() {}
```

In another Groovy script in the same directory as `moduleA.groovy`, write:
```groovy
import moduleA
moduleA.staticFunc()
new moduleA().instanceFunc()
```
Then ctrl+click or use the "Go To Definition" feature of your editor on `moduleA` within each statement. Your cursor should be placed at the first character of `moduleA.groovy`.