### PR TITLE
Fix `NullPointerException` in `ReferenceProvider`

### DIFF
--- a/src/main/java/net/prominic/groovyls/providers/ReferenceProvider.java
+++ b/src/main/java/net/prominic/groovyls/providers/ReferenceProvider.java
@@ -57,6 +57,8 @@ public class ReferenceProvider {
 		List<ASTNode> references = GroovyASTUtils.getReferences(offsetNode, ast);
 		List<Location> locations = references.stream().map(node -> {
 			URI uri = ast.getURI(node);
+			if (uri == null)
+				return null;
 			return GroovyLanguageServerUtils.astNodeToLocation(node, uri);
 		}).filter(location -> location != null).collect(Collectors.toList());
 


### PR DESCRIPTION
Fix a `NullPointerException` thrown in `ReferenceProvider.provideReferences` caused by ctrl+clicking on `referencesBugA` in `referencesBugA.groovy` in the following scenario:
```groovy
// In file referencesBugA.groovy:
referencesBugA

// In another Groovy file in the same directory:
import referencesBugA
```